### PR TITLE
Change Discord Link from https://discord.io/runonflux to https://discord.gg/runonflux in flux website

### DIFF
--- a/Flux-website/blog.html
+++ b/Flux-website/blog.html
@@ -244,7 +244,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -301,7 +301,7 @@
           <div class="wrapper-social blog">
             <div class="flux-social-icons footer social_class blog">
               <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-              <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+              <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
               <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
               <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
               <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
@@ -338,7 +338,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -365,7 +365,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/bug-bounty-program.html
+++ b/Flux-website/bug-bounty-program.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -470,7 +470,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -497,7 +497,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/careers.html
+++ b/Flux-website/careers.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -345,7 +345,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -372,7 +372,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/cve.html
+++ b/Flux-website/cve.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -500,7 +500,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -527,7 +527,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/donate.html
+++ b/Flux-website/donate.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -334,7 +334,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -361,7 +361,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/flux-dapps.html
+++ b/Flux-website/flux-dapps.html
@@ -244,7 +244,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -4873,7 +4873,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -4900,7 +4900,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/flux-nodes.html
+++ b/Flux-website/flux-nodes.html
@@ -244,7 +244,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -802,7 +802,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -829,7 +829,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/flux-social.html
+++ b/Flux-website/flux-social.html
@@ -237,7 +237,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -396,7 +396,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -423,7 +423,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/flux.html
+++ b/Flux-website/flux.html
@@ -245,7 +245,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -3006,7 +3006,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -3033,7 +3033,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/fluxlabs.html
+++ b/Flux-website/fluxlabs.html
@@ -180,7 +180,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -207,7 +207,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/fluxos.html
+++ b/Flux-website/fluxos.html
@@ -245,7 +245,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -514,7 +514,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -541,7 +541,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/index-old.html
+++ b/Flux-website/index-old.html
@@ -245,7 +245,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -288,7 +288,7 @@
       </div>
       <div class="flux-social-icons footer social_class fast">
         <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter fast w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social fast"></a>
-        <a href="https://discord.io/runonflux" target="_blank" class="social_fotter fast w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social fast"></a>
+        <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter fast w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social fast"></a>
         <a href="https://t.me/runonflux" target="_blank" class="social_fotter fast w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social fast"></a>
         <a href="#fotter" class="social_fotter fast jump w-inline-block"><img src="images/Mask-Group-102.png" loading="lazy" alt="" class="img_social fast"></a>
       </div>
@@ -1138,7 +1138,7 @@ function updateSW5DropdownLinks(currentLang){
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -1165,7 +1165,7 @@ function updateSW5DropdownLinks(currentLang){
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/mining.html
+++ b/Flux-website/mining.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -499,7 +499,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -526,7 +526,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/parallel.html
+++ b/Flux-website/parallel.html
@@ -244,7 +244,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -498,7 +498,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -525,7 +525,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/privacy-policy.html
+++ b/Flux-website/privacy-policy.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -351,7 +351,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -378,7 +378,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/roadmap.html
+++ b/Flux-website/roadmap.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -1169,7 +1169,7 @@
               <div class="paragraph-large _11">You can find out more information about our project, development and news by checking out our various social communication channels.<br></div>
             </div>
             <div class="margin-bottom-large">
-              <p class="paragraph-large">If you want to develop with Flux, or simply get more involved with the project, head over to our <a href="https://discord.io/runonflux" target="_blank">Discord</a> channel and bring your value to the decentralization.</p>
+              <p class="paragraph-large">If you want to develop with Flux, or simply get more involved with the project, head over to our <a href="https://discord.gg/runonflux" target="_blank">Discord</a> channel and bring your value to the decentralization.</p>
             </div>
             <a href="https://fluxofficial.medium.com/" target="_blank" class="button_zelcore roadmap w-button">More News</a>
           </div>
@@ -1190,7 +1190,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -1217,7 +1217,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/team.html
+++ b/Flux-website/team.html
@@ -244,7 +244,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -724,7 +724,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -751,7 +751,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/term-conditions.html
+++ b/Flux-website/term-conditions.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -311,7 +311,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -338,7 +338,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/xdao.html
+++ b/Flux-website/xdao.html
@@ -239,7 +239,7 @@
             <div class="wrap-social-icons">
               <div class="flux-social-icons">
                 <a id="w-node-_8a53da83-dfc5-aab0-f34f-da2290f9614f-90f960ce" href="https://twitter.com/RunOnFlux" target="_blank" class="flux_social_link w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://www.facebook.com/runonflux" target="_blank" class="flux_social_link w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="28" alt="" class="social_img_mob"></a>
                 <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="flux_social_link w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
                 <a href="https://t.me/runonflux" class="flux_social_link w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="social_img_mob"></a>
@@ -300,7 +300,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -327,7 +327,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>

--- a/Flux-website/zero-carbon.html
+++ b/Flux-website/zero-carbon.html
@@ -50,7 +50,7 @@
       <div id="w-node-_3c8e2740-6d81-67e9-84d0-78ac2890357f-ac70573f" class="wrapper-social social">
         <div class="flux-social-icons footer social_class social-head">
           <a id="w-node-_3c8e2740-6d81-67e9-84d0-78ac28903581-ac70573f" href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social carbon"></a>
-          <a href="https://discord.io/runonflux" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+          <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
           <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
           <a href="https://github.com/RunOnFlux" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/github_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
           <a href="https://www.linkedin.com/company/flux-official/mycompany/" target="_blank" class="social_fotter carbon w-inline-block"><img src="images/linkdin.svg" loading="lazy" alt="" class="img_social"></a>
@@ -187,7 +187,7 @@
             <div class="wrapper-social">
               <div class="flux-social-icons footer arrow_blue popup">
                 <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt=""></a>
-                <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
+                <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt=""></a>
                 <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt=""></a>
               </div>
             </div>
@@ -214,7 +214,7 @@
         <div class="wrapper-social">
           <div class="flux-social-icons footer social_class">
             <a href="https://twitter.com/RunOnFlux" target="_blank" class="social_fotter w-inline-block"><img src="images/twitter_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
-            <a href="https://discord.io/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
+            <a href="https://discord.gg/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/discord_fux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://www.facebook.com/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/facebook_flux_grey2x.png" loading="lazy" width="27" alt="" class="img_social"></a>
             <a href="https://bitcointalk.org/index.php?topic=2853688.0" target="_blank" class="social_fotter w-inline-block"><img src="images/bitcointalk_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>
             <a href="https://t.me/runonflux" target="_blank" class="social_fotter w-inline-block"><img src="images/telegram_flux_grey2x.png" loading="lazy" alt="" class="img_social"></a>


### PR DESCRIPTION
because some user reported here https://discord.com/channels/404415190835134464/475050615144185856/1165787288370954372 while visit https://discord.io/runonflux in their machine. the browser said to them. This site can’t be reached so i update these link to make better than before